### PR TITLE
Fix LineAccount model and imports

### DIFF
--- a/line-automation-api/src/controllers/accountController.ts
+++ b/line-automation-api/src/controllers/accountController.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from 'express';
-import LineAccount from '../models/lineAccount';
+import { LineAccount } from '../models/LineAccount';
 import LineGroup from '../models/LineGroup';
 import PhoneNumberList from '../models/PhoneNumberList';
 

--- a/line-automation-api/src/controllers/adminController.ts
+++ b/line-automation-api/src/controllers/adminController.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from 'express';
 import RegistrationRequest from '../models/RegistrationRequest';
-import LineAccount from '../models/lineAccount';
+import { LineAccount } from '../models/LineAccount';
 
 export const getAllRegistrationRequests = async (req: Request, res: Response) => {
   try {

--- a/line-automation-api/src/controllers/automationController.ts
+++ b/line-automation-api/src/controllers/automationController.ts
@@ -2,8 +2,8 @@ import { Request, Response } from 'express';
 import { WebSocketServer, WebSocket } from 'ws';
 import axios from 'axios';
 import { URL } from 'url';
-import HttpsProxyAgent from 'https-proxy-agent';
-import LineAccount from '../models/lineAccount';
+import { HttpsProxyAgent } from 'https-proxy-agent';
+import { LineAccount } from '../models/LineAccount';
 import RegistrationRequest from '../models/RegistrationRequest';
 import { AutomationStatus, RegisterRequest, OtpRequest } from '../types';
 

--- a/line-automation-api/src/models/LineAccount.ts
+++ b/line-automation-api/src/models/LineAccount.ts
@@ -1,1 +1,36 @@
- 
+import mongoose, { Document, Schema } from 'mongoose';
+
+export interface ILineAccount extends Document {
+  displayName: string;
+  userId: string;
+  pictureUrl?: string;
+  statusMessage?: string;
+  email?: string;
+  phoneNumber?: string;
+  tags: string[];
+  metadata: Record<string, any>;
+  lineConfigId: mongoose.Types.ObjectId;
+  isBlocked: boolean;
+  lastInteraction: Date;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const LineAccountSchema: Schema = new Schema(
+  {
+    displayName: { type: String, required: true, trim: true },
+    userId: { type: String, required: true, trim: true, unique: true },
+    pictureUrl: { type: String },
+    statusMessage: { type: String },
+    email: { type: String },
+    phoneNumber: { type: String },
+    tags: { type: [String], default: [] },
+    metadata: { type: Map, of: Schema.Types.Mixed, default: {} },
+    lineConfigId: { type: Schema.Types.ObjectId, ref: 'LineConfig', required: true },
+    isBlocked: { type: Boolean, default: false },
+    lastInteraction: { type: Date, default: Date.now }
+  },
+  { timestamps: true }
+);
+
+export const LineAccount = mongoose.model<ILineAccount>('LineAccount', LineAccountSchema);

--- a/line-automation-api/src/routes/adminRoutes.ts
+++ b/line-automation-api/src/routes/adminRoutes.ts
@@ -1,0 +1,13 @@
+import express from 'express';
+import * as adminController from '../controllers/adminController';
+
+const router = express.Router();
+
+// จัดการคำขอลงทะเบียน
+router.get('/admin/registration-requests', adminController.getAllRegistrationRequests);
+router.get('/admin/registration-requests/:id', adminController.getRegistrationRequestById);
+router.put('/admin/registration-requests/:id/status', adminController.updateRegistrationRequestStatus);
+router.post('/admin/registration-requests/:id/create-account', adminController.createAccountFromRequest);
+router.delete('/admin/registration-requests/:id', adminController.deleteRegistrationRequest);
+
+export default router;

--- a/line-automation-api/src/routes/campaign.ts
+++ b/line-automation-api/src/routes/campaign.ts
@@ -1,6 +1,6 @@
 import express, { Request, Response } from 'express';
 import { Campaign, ICampaign, CampaignStatus } from '../models/campaign';
-import { LineAccount } from '../models/lineAccount';
+import { LineAccount } from '../models/LineAccount';
 import { MessageTemplate } from '../models/messageTemplate';
 import { LineConfig } from '../models/lineConfig';
 import mongoose from 'mongoose';

--- a/line-automation-api/src/routes/lineAccount.ts
+++ b/line-automation-api/src/routes/lineAccount.ts
@@ -1,5 +1,5 @@
 import express, { Request, Response } from 'express';
-import { LineAccount, ILineAccount } from '../models/lineAccount';
+import { LineAccount, ILineAccount } from '../models/LineAccount';
 import mongoose from 'mongoose';
 
 const router = express.Router();


### PR DESCRIPTION
## Summary
- add missing LineAccount model implementation
- update imports to use correct case and named exports
- recreate adminRoutes source

## Testing
- `npx tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_6845e8d3cd588332a27d736f4ff6e0dc