### PR TITLE
Implement basic Job tracking

### DIFF
--- a/line-automation-api/src/models/Job.ts
+++ b/line-automation-api/src/models/Job.ts
@@ -1,0 +1,28 @@
+import mongoose, { Document, Schema } from 'mongoose';
+
+export interface IJob extends Document {
+  type: string;
+  accountId?: string;
+  data: any;
+  status: 'pending' | 'in_progress' | 'completed' | 'failed';
+  logs: string[];
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const JobSchema: Schema = new Schema(
+  {
+    type: { type: String, required: true },
+    accountId: { type: String },
+    data: { type: Schema.Types.Mixed },
+    status: {
+      type: String,
+      enum: ['pending', 'in_progress', 'completed', 'failed'],
+      default: 'pending',
+    },
+    logs: { type: [String], default: [] },
+  },
+  { timestamps: true }
+);
+
+export default mongoose.model<IJob>('Job', JobSchema);

--- a/line-automation-api/src/routes/adminRoutes.ts
+++ b/line-automation-api/src/routes/adminRoutes.ts
@@ -10,4 +10,8 @@ router.put('/admin/registration-requests/:id/status', adminController.updateRegi
 router.post('/admin/registration-requests/:id/create-account', adminController.createAccountFromRequest);
 router.delete('/admin/registration-requests/:id', adminController.deleteRegistrationRequest);
 
-export default router; 
+// จัดการงาน (Jobs)
+router.get('/admin/jobs', adminController.getAllJobs);
+router.put('/admin/jobs/:id/status', adminController.updateJobStatus);
+
+export default router;

--- a/line-automation-ui/src/app/adminn/jobs/page.tsx
+++ b/line-automation-ui/src/app/adminn/jobs/page.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  Container,
+  Typography,
+  Table,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableBody,
+  Paper,
+  Chip,
+  IconButton,
+  Snackbar,
+  Alert,
+} from "@mui/material";
+import { Check } from "@mui/icons-material";
+import api from "@/lib/api";
+
+interface Job {
+  _id: string;
+  type: string;
+  accountId?: string;
+  status: string;
+  createdAt: string;
+}
+
+export default function JobsPage() {
+  const [jobs, setJobs] = useState<Job[]>([]);
+  const [message, setMessage] = useState<string | null>(null);
+
+  const fetchJobs = async () => {
+    try {
+      const res = await api.get("/admin/jobs");
+      setJobs(res.data);
+    } catch {
+      setMessage("โหลดข้อมูลล้มเหลว");
+    }
+  };
+
+  const updateStatus = async (id: string, status: string) => {
+    try {
+      await api.put(`/admin/jobs/${id}/status`, { status });
+      setMessage("อัปเดตสำเร็จ");
+      fetchJobs();
+    } catch {
+      setMessage("อัปเดตล้มเหลว");
+    }
+  };
+
+  useEffect(() => {
+    fetchJobs();
+    const rawWsUrl = process.env.NEXT_PUBLIC_WS_URL;
+    if (!rawWsUrl) return;
+    const ws = new WebSocket(rawWsUrl.replace(/^http/, "ws"));
+    ws.onmessage = (ev) => {
+      try {
+        const d = JSON.parse(ev.data);
+        if (d.type === "STATUS_UPDATE" && d.payload?.jobId) fetchJobs();
+      } catch {}
+    };
+    return () => ws.close();
+  }, []);
+
+  return (
+    <Container maxWidth="lg" sx={{ py: 4 }}>
+      <Typography variant="h4" gutterBottom>
+        รายการงาน
+      </Typography>
+      <Paper>
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell>ID</TableCell>
+              <TableCell>ประเภท</TableCell>
+              <TableCell>สถานะ</TableCell>
+              <TableCell>เมื่อ</TableCell>
+              <TableCell>เปลี่ยนสถานะ</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {jobs.map((job) => (
+              <TableRow key={job._id} hover>
+                <TableCell>{job._id.slice(-6)}</TableCell>
+                <TableCell>{job.type}</TableCell>
+                <TableCell>
+                  <Chip label={job.status} size="small" />
+                </TableCell>
+                <TableCell>
+                  {new Date(job.createdAt).toLocaleString()}
+                </TableCell>
+                <TableCell>
+                  <IconButton
+                    onClick={() =>
+                      updateStatus(
+                        job._id,
+                        job.status === "completed" ? "failed" : "completed"
+                      )
+                    }
+                  >
+                    <Check />
+                  </IconButton>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </Paper>
+      <Snackbar
+        open={!!message}
+        autoHideDuration={3000}
+        onClose={() => setMessage(null)}
+        anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
+      >
+        <Alert severity="info" onClose={() => setMessage(null)}>
+          {message}
+        </Alert>
+      </Snackbar>
+    </Container>
+  );
+}

--- a/line-automation-ui/src/app/create-group/page.tsx
+++ b/line-automation-ui/src/app/create-group/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Container, Typography, TextField, Button, Stack, Snackbar, Alert } from '@mui/material';
 import api from '@/lib/api';
 
@@ -8,14 +8,33 @@ export default function CreateGroupPage() {
   const [groupName, setGroupName] = useState('');
   const [loading, setLoading] = useState(false);
   const [message, setMessage] = useState<string | boolean>(false);
+  const [jobId, setJobId] = useState('');
+  const [jobStatus, setJobStatus] = useState('');
+
+  useEffect(() => {
+    if (!jobId) return;
+    const rawWsUrl = process.env.NEXT_PUBLIC_WS_URL;
+    if (!rawWsUrl) return;
+    const ws = new WebSocket(rawWsUrl.replace(/^http/, 'ws'));
+    ws.onmessage = (event) => {
+      try {
+        const data = JSON.parse(event.data);
+        if (data.type === 'STATUS_UPDATE' && data.payload?.jobId === jobId) {
+          setJobStatus(data.payload.status);
+        }
+      } catch {}
+    };
+    return () => ws.close();
+  }, [jobId]);
 
   const handleSubmit = async () => {
     if (!groupName.trim()) return;
     setLoading(true);
     try {
-      await api.post('/create-group', { name: groupName });
+      const res = await api.post('/create-group', { name: groupName });
       setMessage('สร้างกลุ่มสำเร็จ');
       setGroupName('');
+      if (res.data.jobId) setJobId(res.data.jobId);
     } catch {
       setMessage('เกิดข้อผิดพลาด');
     } finally {
@@ -38,6 +57,9 @@ export default function CreateGroupPage() {
           {loading ? 'กำลังสร้าง…' : 'สร้างกลุ่ม'}
         </Button>
       </Stack>
+      {jobId && (
+        <Typography mt={2}>สถานะงาน: {jobStatus || 'pending'}</Typography>
+      )}
       <Snackbar
         open={!!message}
         autoHideDuration={3000}


### PR DESCRIPTION
## Summary
- add Mongoose Job model
- create jobs in account controller actions and broadcast status
- expose job management endpoints in admin controller and routes
- show job status in add friends, create group, and send message pages
- add admin dashboard page to list and update job status

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run build` *(fails to compile due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6845fafd278c8332ba8a13faba2933c3