### PR TITLE
Implement account-aware friend adding jobs

### DIFF
--- a/line-automation-api/src/routes/accountRoutes.ts
+++ b/line-automation-api/src/routes/accountRoutes.ts
@@ -10,6 +10,7 @@ router.get('/accounts/:id', accountController.getAccountById);
 // การจัดการกลุ่ม และเพื่อน
 router.get('/accounts/:accountId/groups', accountController.getGroupsByAccountId);
 router.post('/add-friends', accountController.addFriends);
+router.get('/add-friends-jobs', accountController.getAddFriendJobs);
 router.post('/create-group', accountController.createGroup);
 router.post('/send-message', accountController.sendMessageToGroup);
 

--- a/line-automation-api/src/websocket.ts
+++ b/line-automation-api/src/websocket.ts
@@ -4,7 +4,7 @@ import { WebSocketServer, WebSocket } from 'ws';
 const clients = new Set<WebSocket>();
 
 // ประเภทข้อความที่ส่งผ่าน WebSocket
-type WSMessageType = 'NOTIFICATION' | 'STATUS_UPDATE' | 'ERROR';
+type WSMessageType = 'NOTIFICATION' | 'STATUS_UPDATE' | 'ERROR' | 'ADD_FRIENDS_UPDATE';
 
 // โครงสร้างข้อความ WebSocket
 interface WSMessage {

--- a/line-automation-ui/src/app/add-friends/page.tsx
+++ b/line-automation-ui/src/app/add-friends/page.tsx
@@ -1,30 +1,70 @@
 'use client';
 
-import { useState } from 'react';
-import { Container, Typography, TextField, Button, Stack, Snackbar, Alert } from '@mui/material';
+import { useState, useEffect } from 'react';
+import { Container, Typography, Button, Stack, Snackbar, Alert, Select, MenuItem, FormControl, InputLabel, LinearProgress } from '@mui/material';
 import api from '@/lib/api';
 
 export default function AddFriendsPage() {
-  const [userIds, setUserIds] = useState(''); // comma separated
+  const [accounts, setAccounts] = useState<any[]>([]);
+  const [lists, setLists] = useState<any[]>([]);
+  const [accountId, setAccountId] = useState('');
+  const [listId, setListId] = useState('');
   const [loading, setLoading] = useState(false);
   const [message, setMessage] = useState<string | boolean>(false);
+  const [progress, setProgress] = useState<{ processed: number; total: number; status: string } | null>(null);
+  const [jobId, setJobId] = useState<string | null>(null);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const [accRes, listRes] = await Promise.all([
+          api.get('/accounts'),
+          api.get('/phone-lists'),
+        ]);
+        setAccounts(accRes.data);
+        setLists(listRes.data);
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    load();
+  }, []);
+
+  useEffect(() => {
+    if (!jobId) return;
+    const rawWsUrl = process.env.NEXT_PUBLIC_WS_URL;
+    if (!rawWsUrl) return;
+    const wsUrl = rawWsUrl.replace(/^http/, 'ws');
+    const socket = new WebSocket(wsUrl);
+    socket.onmessage = (event) => {
+      try {
+        const data = JSON.parse(event.data);
+        if (data.type === 'addFriendsUpdate' && data.payload.id === jobId) {
+          setProgress({ processed: data.payload.processed, total: data.payload.total, status: data.payload.status });
+          if (data.payload.status === 'completed') {
+            socket.close();
+            setLoading(false);
+            setMessage('เพิ่มเพื่อนเสร็จสิ้น');
+          }
+        }
+      } catch {}
+    };
+    socket.onerror = console.error;
+    return () => socket.close();
+  }, [jobId]);
 
   const handleSubmit = async () => {
-    const ids = userIds
-      .split(',')
-      .map((id) => id.trim())
-      .filter(Boolean);
-    if (!ids.length) return;
+    const list = lists.find((l: any) => l._id === listId);
+    if (!accountId || !list) return;
 
     setLoading(true);
+    setProgress({ processed: 0, total: list.phoneNumbers.length, status: 'running' });
     try {
-      await api.post('/add-friends', { ids });
-      setMessage('เพิ่มเพื่อนสำเร็จ');
-      setUserIds('');
+      const res = await api.post('/add-friends', { accountId, ids: list.phoneNumbers });
+      setJobId(res.data.jobId);
     } catch {
-      setMessage('เกิดข้อผิดพลาด');
-    } finally {
       setLoading(false);
+      setMessage('เกิดข้อผิดพลาด');
     }
   };
 
@@ -34,15 +74,28 @@ export default function AddFriendsPage() {
         เพิ่มเพื่อน
       </Typography>
       <Stack spacing={2}>
-        <TextField
-          label="User IDs (คั่นด้วย ,)"
-          value={userIds}
-          onChange={(e) => setUserIds(e.target.value)}
-          multiline
-        />
-        <Button variant="contained" onClick={handleSubmit} disabled={loading}>
+        <FormControl fullWidth>
+          <InputLabel>บัญชี</InputLabel>
+          <Select value={accountId} label="บัญชี" onChange={(e) => setAccountId(e.target.value)}>
+            {accounts.map(acc => (
+              <MenuItem key={acc._id} value={acc._id}>{acc.displayName || acc.phoneNumber}</MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+        <FormControl fullWidth>
+          <InputLabel>ชุดเบอร์</InputLabel>
+          <Select value={listId} label="ชุดเบอร์" onChange={(e) => setListId(e.target.value)}>
+            {lists.map(list => (
+              <MenuItem key={list._id} value={list._id}>{list.name}</MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+        <Button variant="contained" onClick={handleSubmit} disabled={loading || !accountId || !listId}>
           {loading ? 'กำลังเพิ่ม…' : 'เพิ่มเพื่อน'}
         </Button>
+        {progress && (
+          <LinearProgress variant="determinate" value={(progress.processed / progress.total) * 100} />
+        )}
       </Stack>
       <Snackbar
         open={!!message}
@@ -50,7 +103,7 @@ export default function AddFriendsPage() {
         onClose={() => setMessage(false)}
         anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
       >
-        <Alert severity={message === 'เพิ่มเพื่อนสำเร็จ' ? 'success' : 'error'}>{message}</Alert>
+        <Alert severity={message === 'เพิ่มเพื่อนเสร็จสิ้น' ? 'success' : 'error'}>{message}</Alert>
       </Snackbar>
     </Container>
   );

--- a/line-automation-ui/src/app/adminn/page.tsx
+++ b/line-automation-ui/src/app/adminn/page.tsx
@@ -50,6 +50,14 @@ interface RegistrationRequest {
   adminNotes?: string;
 }
 
+interface FriendJob {
+  id: string;
+  accountId: string;
+  total: number;
+  processed: number;
+  status: string;
+}
+
 const statusOptions = [
   { value: "all", label: "ทั้งหมด" },
   { value: "pending", label: "รอดำเนินการ" },
@@ -74,6 +82,7 @@ export default function AdminPage() {
   const [search, setSearch] = useState("");
   const [statusFilter, setStatusFilter] = useState("all");
   const [refreshing, setRefreshing] = useState(false);
+  const [friendJobs, setFriendJobs] = useState<FriendJob[]>([]);
 
   // โหลดข้อมูล
   const fetchRequests = async () => {
@@ -106,6 +115,17 @@ export default function AdminPage() {
         const data = JSON.parse(event.data);
         if (data.type === "statusUpdate" && (data.phoneNumber || data.details?.requestId)) {
           fetchRequests();
+        }
+        if (data.type === "addFriendsUpdate") {
+          setFriendJobs(prev => {
+            const idx = prev.findIndex(j => j.id === data.payload.id);
+            if (idx >= 0) {
+              const updated = [...prev];
+              updated[idx] = { ...updated[idx], ...data.payload };
+              return updated;
+            }
+            return [...prev, data.payload];
+          });
         }
       } catch {}
     };
@@ -265,6 +285,31 @@ export default function AdminPage() {
           }}
         />
       </Stack>
+      {friendJobs.length > 0 && (
+        <Box mb={3}>
+          <Typography variant="h6" gutterBottom>งานเพิ่มเพื่อน</Typography>
+          <TableContainer component={Paper} sx={{ mb: 2 }}>
+            <Table size="small">
+              <TableHead>
+                <TableRow>
+                  <TableCell>Account</TableCell>
+                  <TableCell>Progress</TableCell>
+                  <TableCell>Status</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {friendJobs.map(job => (
+                  <TableRow key={job.id}>
+                    <TableCell>{job.accountId}</TableCell>
+                    <TableCell>{job.processed}/{job.total}</TableCell>
+                    <TableCell>{job.status}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        </Box>
+      )}
       <TableContainer component={Paper}>
         <Table size="small">
           <TableHead>


### PR DESCRIPTION
## Summary
- fetch accounts and number sets for add friends page
- send selected account with `/add-friends` and track progress via websocket
- expose add friend jobs from API and broadcast job updates
- show friend-adding jobs on admin page

## Testing
- `npm run build` *(fails: Cannot find module 'axios' or 'https-proxy-agent')*

------
https://chatgpt.com/codex/tasks/task_e_6845faf9fc3c8332ba0513b84c2ac7ef