### PR TITLE
Add account and group selection for sending messages

### DIFF
--- a/line-automation-api/src/routes/accountRoutes.ts
+++ b/line-automation-api/src/routes/accountRoutes.ts
@@ -11,6 +11,7 @@ router.get('/accounts/:id', accountController.getAccountById);
 router.get('/accounts/:accountId/groups', accountController.getGroupsByAccountId);
 router.post('/add-friends', accountController.addFriends);
 router.post('/create-group', accountController.createGroup);
+// ส่งข้อความต้องระบุ accountId, groupId และ message ใน body
 router.post('/send-message', accountController.sendMessageToGroup);
 
 // การจัดการชุดเบอร์โทรศัพท์


### PR DESCRIPTION
## Summary
- fetch accounts and groups from API
- allow selecting account and group before sending a message
- send account and group ids to backend
- validate accountId and groupId in the API controller
- document required fields in send-message route

## Testing
- `npm run build` *(fails: Cannot find module 'axios')*

------
https://chatgpt.com/codex/tasks/task_e_684601730ff48332beb3835d94aec755