### PR TITLE
Add account selection for group creation

### DIFF
--- a/line-automation-api/src/controllers/accountController.ts
+++ b/line-automation-api/src/controllers/accountController.ts
@@ -72,12 +72,16 @@ export const addFriends = async (req: Request, res: Response) => {
 
 export const createGroup = async (req: Request, res: Response) => {
   try {
-    const { name } = req.body;
-    if (!name) {
+    const { name, accountId } = req.body;
+    if (!name || !accountId) {
       return res.status(400).json({ message: 'กรุณาระบุข้อมูลให้ครบถ้วน' });
     }
-    const job = await createJob('create_group', undefined, { name });
-    const newGroup = new LineGroup({ name, accountId: '', memberCount: 0 });
+    const account = await LineAccount.findById(accountId);
+    if (!account) {
+      return res.status(404).json({ message: 'ไม่พบบัญชีที่ระบุ' });
+    }
+    const job = await createJob('create_group', accountId, { name });
+    const newGroup = new LineGroup({ name, accountId, memberCount: 0 });
     await newGroup.save();
     await updateJobStatus(job, 'completed');
     return res.status(201).json({ message: 'สร้างกลุ่มสำเร็จ', group: newGroup, jobId: job._id });

--- a/line-automation-ui/src/app/create-group/page.js
+++ b/line-automation-ui/src/app/create-group/page.js
@@ -20,14 +20,52 @@ function CreateGroupPage() {
     const [groupName, setGroupName] = (0, react_1.useState)('');
     const [loading, setLoading] = (0, react_1.useState)(false);
     const [message, setMessage] = (0, react_1.useState)(false);
+    const [jobId, setJobId] = (0, react_1.useState)('');
+    const [jobStatus, setJobStatus] = (0, react_1.useState)('');
+    const [accounts, setAccounts] = (0, react_1.useState)([]);
+    const [accountId, setAccountId] = (0, react_1.useState)('');
+    (0, react_1.useEffect)(() => {
+        if (!jobId)
+            return;
+        const rawWsUrl = process.env.NEXT_PUBLIC_WS_URL;
+        if (!rawWsUrl)
+            return;
+        const ws = new WebSocket(rawWsUrl.replace(/^http/, 'ws'));
+        ws.onmessage = (event) => {
+            try {
+                const data = JSON.parse(event.data);
+                if (data.type === 'STATUS_UPDATE' && (data.payload === null || data.payload === void 0 ? void 0 : data.payload.jobId) === jobId) {
+                    setJobStatus(data.payload.status);
+                }
+            }
+            catch (_a) { }
+        };
+        return () => ws.close();
+    }, [jobId]);
+    (0, react_1.useEffect)(() => {
+        const fetchAccounts = () => __awaiter(this, void 0, void 0, function* () {
+            try {
+                const res = yield api_1.default.get('/accounts');
+                setAccounts(res.data);
+                if (res.data.length > 0)
+                    setAccountId(res.data[0]._id);
+            }
+            catch (err) {
+                console.error(err);
+            }
+        });
+        fetchAccounts();
+    }, []);
     const handleSubmit = () => __awaiter(this, void 0, void 0, function* () {
-        if (!groupName.trim())
+        if (!groupName.trim() || !accountId)
             return;
         setLoading(true);
         try {
-            yield api_1.default.post('/create-group', { name: groupName });
+            const res = yield api_1.default.post('/create-group', { name: groupName, accountId });
             setMessage('สร้างกลุ่มสำเร็จ');
             setGroupName('');
+            if (res.data.jobId)
+                setJobId(res.data.jobId);
         }
         catch (_a) {
             setMessage('เกิดข้อผิดพลาด');
@@ -41,11 +79,18 @@ function CreateGroupPage() {
         สร้างกลุ่ม LINE
       </material_1.Typography>
       <material_1.Stack spacing={2}>
+        <material_1.FormControl fullWidth>
+          <material_1.InputLabel id="account-select-label">บัญชี LINE</material_1.InputLabel>
+          <material_1.Select labelId="account-select-label" label="บัญชี LINE" value={accountId} onChange={(e) => setAccountId(e.target.value)}>
+            {accounts.map((acc) => (<material_1.MenuItem key={acc._id} value={acc._id}>{acc.displayName || acc.userId}</material_1.MenuItem>))}
+          </material_1.Select>
+        </material_1.FormControl>
         <material_1.TextField label="ชื่อกลุ่ม" value={groupName} onChange={(e) => setGroupName(e.target.value)}/>
         <material_1.Button variant="contained" onClick={handleSubmit} disabled={loading}>
           {loading ? 'กำลังสร้าง…' : 'สร้างกลุ่ม'}
         </material_1.Button>
       </material_1.Stack>
+      {jobId && (<material_1.Typography mt={2}>สถานะงาน: {jobStatus || 'pending'}</material_1.Typography>)}
       <material_1.Snackbar open={!!message} autoHideDuration={3000} onClose={() => setMessage(false)} anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}>
         <material_1.Alert severity={message === 'สร้างกลุ่มสำเร็จ' ? 'success' : 'error'}>{message}</material_1.Alert>
       </material_1.Snackbar>

--- a/line-automation-ui/src/app/create-group/page.tsx
+++ b/line-automation-ui/src/app/create-group/page.tsx
@@ -1,7 +1,19 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { Container, Typography, TextField, Button, Stack, Snackbar, Alert } from '@mui/material';
+import {
+  Container,
+  Typography,
+  TextField,
+  Button,
+  Stack,
+  Snackbar,
+  Alert,
+  Select,
+  MenuItem,
+  FormControl,
+  InputLabel,
+} from '@mui/material';
 import api from '@/lib/api';
 
 export default function CreateGroupPage() {
@@ -10,6 +22,8 @@ export default function CreateGroupPage() {
   const [message, setMessage] = useState<string | boolean>(false);
   const [jobId, setJobId] = useState('');
   const [jobStatus, setJobStatus] = useState('');
+  const [accounts, setAccounts] = useState<any[]>([]);
+  const [accountId, setAccountId] = useState('');
 
   useEffect(() => {
     if (!jobId) return;
@@ -27,11 +41,24 @@ export default function CreateGroupPage() {
     return () => ws.close();
   }, [jobId]);
 
+  useEffect(() => {
+    const fetchAccounts = async () => {
+      try {
+        const res = await api.get('/accounts');
+        setAccounts(res.data);
+        if (res.data.length > 0) setAccountId(res.data[0]._id);
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    fetchAccounts();
+  }, []);
+
   const handleSubmit = async () => {
-    if (!groupName.trim()) return;
+    if (!groupName.trim() || !accountId) return;
     setLoading(true);
     try {
-      const res = await api.post('/create-group', { name: groupName });
+      const res = await api.post('/create-group', { name: groupName, accountId });
       setMessage('สร้างกลุ่มสำเร็จ');
       setGroupName('');
       if (res.data.jobId) setJobId(res.data.jobId);
@@ -48,6 +75,21 @@ export default function CreateGroupPage() {
         สร้างกลุ่ม LINE
       </Typography>
       <Stack spacing={2}>
+        <FormControl fullWidth>
+          <InputLabel id="account-select-label">บัญชี LINE</InputLabel>
+          <Select
+            labelId="account-select-label"
+            label="บัญชี LINE"
+            value={accountId}
+            onChange={(e) => setAccountId(e.target.value as string)}
+          >
+            {accounts.map((acc) => (
+              <MenuItem key={acc._id} value={acc._id}>
+                {acc.displayName || acc.userId}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
         <TextField
           label="ชื่อกลุ่ม"
           value={groupName}


### PR DESCRIPTION
## Summary
- fetch accounts on the create-group page and allow selecting one
- send the selected accountId when creating a group
- validate accountId on the API and store it when creating groups

## Testing
- `npm --prefix line-automation-ui run lint` *(fails: A `require()` style import is forbidden, etc.)*
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6846017260c88332a3a05f3c3fea203b