### PR TITLE
Allow manual chunk input

### DIFF
--- a/line-automation-api/src/controllers/accountController.ts
+++ b/line-automation-api/src/controllers/accountController.ts
@@ -115,11 +115,18 @@ export const getPhoneNumberLists = async (req: Request, res: Response) => {
 
 export const createPhoneNumberList = async (req: Request, res: Response) => {
   try {
+    // chunks should already be grouped by the client
     const { name, inputType, rawData, chunks } = req.body;
     if (!name || !inputType || !chunks || !Array.isArray(chunks)) {
       return res.status(400).json({ message: 'กรุณาระบุข้อมูลให้ครบถ้วน' });
     }
-    const newList = new PhoneNumberList({ name, inputType, rawData, chunks, userId: '' });
+    const newList = new PhoneNumberList({
+      name,
+      inputType,
+      rawData,
+      chunks, // store provided chunks as-is
+      userId: '',
+    });
     await newList.save();
     return res.status(201).json({ message: 'สร้างชุดเบอร์โทรศัพท์สำเร็จ', list: newList });
   } catch (error) {


### PR DESCRIPTION
## Summary
- allow one-set-per-line chunk input for number sets
- send those chunks directly to API
- store provided chunks on the server without modification

## Testing
- `npm run build` *(fails: Cannot find module 'axios')*

------
https://chatgpt.com/codex/tasks/task_e_68460170b7b48332b8750ec69f843956